### PR TITLE
Deterministic Bucket and File Ids

### DIFF
--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -2,6 +2,7 @@
 
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
+const storj = require('storj-lib');
 
 /**
  * Represents a storage bucket
@@ -31,7 +32,12 @@ var Bucket = new mongoose.Schema({
   },
   name: {
     type: String,
-    default: 'New Bucket'
+    default: function() {
+      return 'bucket-xxxx'.replace(/x/g, function() {
+        var num = Math.floor(Math.random() * 16);
+        return num.toString(16);
+      });
+    }
   },
   created: {
     type: Date,
@@ -58,6 +64,7 @@ Bucket.set('toObject', {
  */
 Bucket.statics.create = function(user, data, callback) {
   let Bucket = this;
+
   let bucket = new Bucket({
     status: 'Active',
     name: data.name,
@@ -65,8 +72,14 @@ Bucket.statics.create = function(user, data, callback) {
     user: user._id
   });
 
+  var bucketId = storj.utils.calculateBucketId(user._id, bucket.name);
+  bucket._id = mongoose.Types.ObjectId(bucketId);
+
   bucket.save(function(err) {
     if (err) {
+      if (err.code === 11000) {
+        return callback(new Error('Name already used by another bucket'));
+      }
       return callback(err);
     }
 

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -3,7 +3,7 @@
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 const storj = require('storj-lib');
-
+const crypto = require('crypto');
 /**
  * Represents a storage bucket
  * @constructor
@@ -33,10 +33,7 @@ var Bucket = new mongoose.Schema({
   name: {
     type: String,
     default: function() {
-      return 'bucket-xxxx'.replace(/x/g, function() {
-        var num = Math.floor(Math.random() * 16);
-        return num.toString(16);
-      });
+      return 'Bucket-' + crypto.randomBytes(3).toString('hex');
     }
   },
   created: {

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -33,6 +33,10 @@ var BucketEntry = new mongoose.Schema({
     default: function() {
       return Date.now() + ms('90d');
     }
+  },
+  created: {
+    type: Date,
+    default: Date.now
   }
 });
 

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -4,6 +4,7 @@ const ms = require('ms');
 const mongoose = require('mongoose');
 const mimetypes = require('mime-db');
 const SchemaOptions = require('../options');
+const storj = require('storj-lib');
 
 /**
  * Represents a bucket entry that points to a file
@@ -53,6 +54,40 @@ BucketEntry.set('toObject', {
     delete ret.name;
   }
 });
+
+/**
+ * Creates a BucketEntry
+ * @param {String} bucket - Bucket id
+ * @param {String} frame - Frame id
+ * @param {String} mimetype - Mime type of file
+ * @param {String} filename - File name
+ * @param {Function} callback
+ */
+BucketEntry.statics.create = function(data, callback) {
+  let BucketEntry = this;
+
+  let entry = new BucketEntry({
+    bucket: data.bucket,
+    frame: data.frame,
+    mimetype: data.mimetype,
+    name: data.filename
+  });
+
+  // use deterministic file id based on bucketId and fileName
+  var fileId = storj.utils.calculateFileId(data.bucket.toString(), entry.name);
+  entry._id = mongoose.Types.ObjectId(fileId);
+
+  entry.save(function(err) {
+    if (err) {
+      if (err.code === 11000) {
+        return callback(new Error('Name already used in this bucket'));
+      }
+      return callback(err);
+    }
+    callback(null, entry);
+  });
+
+};
 
 module.exports = function(connection) {
   return connection.model('BucketEntry', BucketEntry);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mongoose": "^4.6.1",
     "mongoose-types": "^1.0.3",
     "ms": "^0.7.1",
-    "storj-lib": "^4.0.0-rc.3",
+    "storj-lib": "^4.0.1",
     "storj-service-error-types": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/Storj/service-storage-models#readme",
   "dependencies": {
+    "crypto": "0.0.3",
     "elliptic": "^6.3.2",
     "hat": "0.0.3",
     "mime-db": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/Storj/service-storage-models#readme",
   "dependencies": {
-    "crypto": "0.0.3",
     "elliptic": "^6.3.2",
     "hat": "0.0.3",
     "mime-db": "^1.24.0",

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -32,13 +32,17 @@ describe('Storage/models/Bucket', function() {
   describe('#create', function() {
 
     it('should create the bucket with the default props', function(done) {
+      var expectedBucketId = storj.utils.calculateBucketId('user@domain.tld', 'New Bucket');
+
       Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket' }, function(err, bucket) {
         expect(err).to.not.be.instanceOf(Error);
+        expect(bucket.id).to.equal(expectedBucketId);
         expect(bucket.name).to.equal('New Bucket');
         expect(bucket.storage).to.equal(0);
         expect(bucket.transfer).to.equal(0);
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
+          expect(bucket.id).to.equal(expectedBucketId);
           expect(bucket.name).to.equal('New Bucket');
           expect(bucket.storage).to.equal(0);
           expect(bucket.transfer).to.equal(0);

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -32,20 +32,30 @@ describe('Storage/models/Bucket', function() {
   describe('#create', function() {
 
     it('should create the bucket with the default props', function(done) {
-      Bucket.create({ _id: 'user@domain.tld' }, {}, function(err, bucket) {
+      Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket' }, function(err, bucket) {
         expect(err).to.not.be.instanceOf(Error);
+        expect(bucket.name).to.equal('New Bucket');
         expect(bucket.storage).to.equal(0);
         expect(bucket.transfer).to.equal(0);
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
+          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.storage).to.equal(0);
           expect(bucket.transfer).to.equal(0);
           expect(bucket.status).to.equal('Active');
-          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.pubkeys).to.have.lengthOf(0);
           expect(bucket.user).to.equal('user@domain.tld');
           done();
         });
+      });
+    });
+
+    it('should reject a duplicate name', function(done) {
+      Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket' }, function(err) {
+        expect(err.message).to.equal(
+          'Name already used by another bucket'
+        );
+        done();
       });
     });
 
@@ -76,7 +86,6 @@ describe('Storage/models/Bucket', function() {
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
           expect(bucket.status).to.equal('Active');
-          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.pubkeys[0]).to.equal(publicKey1);
           expect(bucket.pubkeys[1]).to.equal(publicKey2);
           expect(bucket.user).to.equal('user@domain.tld');
@@ -94,7 +103,6 @@ describe('Storage/models/Bucket', function() {
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
           expect(bucket.status).to.equal('Active');
-          expect(bucket.name).to.equal('New Bucket');
           expect(bucket.pubkeys[0]).to.equal(publicKey);
           expect(bucket.pubkeys[1]).to.equal(publicKey);
           expect(bucket.user).to.equal('user@domain.tld');

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -36,19 +36,40 @@ after(function(done) {
 
 describe('Storage/models/BucketEntry', function() {
 
+  var bucketA;
+
   it('should create the bucket entry metadata', function(done) {
-    Bucket.create({ _id: 'user@domain.tld' }, {}, function(err, bucket) {
+    Bucket.create({ _id: 'user@domain.tld' }, { name: 'Bucket A' }, function(err, bucket) {
+      bucketA = bucket;
       var frame = new Frame({
 
       });
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
-        var entry = new BucketEntry({
-          file: frame._id,
+        var entry = BucketEntry.create({
+          frame: frame._id,
           bucket: bucket._id,
           filename: 'test.txt'
+        }, function(err){
+          done();
         });
-        entry.save(done);
+      });
+    });
+  });
+
+  it('should reject a duplicate name in this same bucket', function(done) {
+    var frame = new Frame({
+
+    });
+    frame.save(function(err) {
+      expect(err).to.not.be.instanceOf(Error);
+      var entry = BucketEntry.create({
+        frame: frame._id,
+        bucket: bucketA._id,
+        filename: 'test.txt'
+      }, function(err){
+        expect(err.message).to.equal('Name already used in this bucket');
+        done();
       });
     });
   });
@@ -60,13 +81,12 @@ describe('Storage/models/BucketEntry', function() {
       });
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
-        var entry = new BucketEntry({
+        var entry = BucketEntry.create({
           frame: frame._id,
           mimetype: 'invalid/mimetype',
           bucket: bucket._id,
           filename: 'test.txt'
-        });
-        entry.save(function(err) {
+        }, function(err) {
           expect(err).to.be.instanceOf(Error);
           done();
         });


### PR DESCRIPTION
This depends on https://github.com/Storj/core/pull/477 being merged into core. It adds deterministic bucket id and file id support to service-storage-models as part of https://github.com/Storj/core-cli/issues/14 and https://github.com/Storj/bridge/issues/186.

This adds a BucketEntry.create static function, makes the test cases now use this function, adds a custom error message for duplicate id errors, makes the default bucket name random to avoid collisions in many of the tests, and makes Bucket.create and BucketEntry.create deterministicly generate ids
