### PR TITLE
Feature/public buckets

### DIFF
--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -40,17 +40,19 @@ var Bucket = new mongoose.Schema({
     type: Date,
     default: Date.now
   },
-  publicPermissions:{
+  publicPermissions: {
     type: [{
       type: String,
       enum: ['PUSH', 'PULL'],
       required: false
     }],
-    default: []
+    default: [],
+    required: true
   },
   encryptionKey: {
     type: String,
-    default: ''
+    default: '',
+    required: true
   },
 });
 

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -40,10 +40,13 @@ var Bucket = new mongoose.Schema({
     type: Date,
     default: Date.now
   },
-  isPublic: {
-    type: String,
-    enum: ['true', 'false'],
-    default: 'false'
+  publicPermissions:{
+    type: [{
+      type: String,
+      enum: ['PUSH', 'PULL'],
+      required: false
+    }],
+    default: []
   },
   encryptionKey: {
     type: String,

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -39,7 +39,16 @@ var Bucket = new mongoose.Schema({
   created: {
     type: Date,
     default: Date.now
-  }
+  },
+  isPublic: {
+    type: String,
+    enum: ['true', 'false'],
+    default: 'false'
+  },
+  encryptionKey: {
+    type: String,
+    default: ''
+  },
 });
 
 Bucket.plugin(SchemaOptions);

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -46,13 +46,11 @@ var Bucket = new mongoose.Schema({
       enum: ['PUSH', 'PULL'],
       required: false
     }],
-    default: [],
-    required: true
+    default: []
   },
   encryptionKey: {
     type: String,
-    default: '',
-    required: true
+    default: ''
   },
 });
 

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -44,7 +44,6 @@ var Bucket = new mongoose.Schema({
     type: [{
       type: String,
       enum: ['PUSH', 'PULL'],
-      required: false
     }],
     default: []
   },

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -40,17 +40,41 @@ describe('Storage/models/Bucket', function() {
         expect(bucket.name).to.equal('New Bucket');
         expect(bucket.storage).to.equal(0);
         expect(bucket.transfer).to.equal(0);
-        expect(bucket.isPublic).to.equal('false');
+        expect(bucket.publicPermissions.length).to.equal(0);
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
           expect(bucket.id).to.equal(expectedBucketId);
           expect(bucket.name).to.equal('New Bucket');
           expect(bucket.storage).to.equal(0);
           expect(bucket.transfer).to.equal(0);
-          expect(bucket.isPublic).to.equal('false');
+          expect(bucket.publicPermissions.length).to.equal(0);
           expect(bucket.status).to.equal('Active');
           expect(bucket.pubkeys).to.have.lengthOf(0);
           expect(bucket.user).to.equal('user@domain.tld');
+          done();
+        });
+      });
+    });
+
+    it('should allow an update to to the publicPermissions', function(done) {
+      Bucket.create({ _id: 'user@domain.tld' }, {}, function(err, bucket) {
+        expect(err).to.not.be.instanceOf(Error);
+        bucket.publicPermissions = ['PUSH', 'PULL'];
+        bucket.save(function(err, bucket){
+          expect(err).to.not.be.instanceOf(Error);
+          expect(bucket.publicPermissions.indexOf('PUSH')).to.not.equal(-1);
+          expect(bucket.publicPermissions.indexOf('PULL')).to.not.equal(-1);
+          done();
+        });
+      });
+    });
+
+    it('should reject invalid permissions request', function(done) {
+      Bucket.create({ _id: 'user@domain.tld' }, {}, function(err, bucket) {
+        expect(err).to.not.be.instanceOf(Error);
+        bucket.publicPermissions = ['INVALID'];
+        bucket.save(function(err, bucket){
+          expect(err).to.be.instanceOf(Error);
           done();
         });
       });

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -40,12 +40,14 @@ describe('Storage/models/Bucket', function() {
         expect(bucket.name).to.equal('New Bucket');
         expect(bucket.storage).to.equal(0);
         expect(bucket.transfer).to.equal(0);
+        expect(bucket.isPublic).to.equal('false');
         Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
           expect(bucket.id).to.equal(expectedBucketId);
           expect(bucket.name).to.equal('New Bucket');
           expect(bucket.storage).to.equal(0);
           expect(bucket.transfer).to.equal(0);
+          expect(bucket.isPublic).to.equal('false');
           expect(bucket.status).to.equal('Active');
           expect(bucket.pubkeys).to.have.lengthOf(0);
           expect(bucket.user).to.equal('user@domain.tld');


### PR DESCRIPTION
This adds two fields needed for making a bucket public, the encryptionKey (which will be the rmd160sha256(deterministicSeed + bucketId)) and a field which marks which operations are public (PUSH and/or PULL). 
