### PR TITLE
Fix naming for BucketEntry.create

### DIFF
--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -64,7 +64,7 @@ BucketEntry.set('toObject', {
  * @param {String} bucket - Bucket id
  * @param {String} frame - Frame id
  * @param {String} mimetype - Mime type of file
- * @param {String} filename - File name
+ * @param {String} name - File name
  * @param {Function} callback
  */
 BucketEntry.statics.create = function(data, callback) {
@@ -74,7 +74,7 @@ BucketEntry.statics.create = function(data, callback) {
     bucket: data.bucket,
     frame: data.frame,
     mimetype: data.mimetype,
-    name: data.filename
+    name: data.name
   });
 
   // use deterministic file id based on bucketId and fileName

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -52,7 +52,7 @@ describe('Storage/models/BucketEntry', function() {
         var entry = BucketEntry.create({
           frame: frame._id,
           bucket: bucket._id,
-          filename: 'test.txt'
+          name: 'test.txt'
         }, function(err, entry){
           expect(entry.id).to.equal(expectedFileId);
           done();
@@ -70,7 +70,7 @@ describe('Storage/models/BucketEntry', function() {
       var entry = BucketEntry.create({
         frame: frame._id,
         bucket: expectedBucketId,
-        filename: 'test.txt'
+        name: 'test.txt'
       }, function(err){
         expect(err.message).to.equal('Name already used in this bucket');
         done();
@@ -89,7 +89,7 @@ describe('Storage/models/BucketEntry', function() {
           frame: frame._id,
           mimetype: 'invalid/mimetype',
           bucket: bucket._id,
-          filename: 'test.txt'
+          name: 'test.txt'
         }, function(err) {
           expect(err).to.be.instanceOf(Error);
           done();


### PR DESCRIPTION
Make BucketEntry.create the same as the db entry
