### PR TITLE
add npm link deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "chai": "^3.5.0",
     "mocha": "^3.0.2",
     "sinon": "^1.17.6"
+  },
+  "devopsBase": {
+    "npmLinkDeps": {
+      "storj-lib": "core"
+    }
   }
 }


### PR DESCRIPTION
This is required for proper automatic unpublished npm dependency linking in all environments
