### PR TITLE
Replace/overwrite existing file instead of throwing error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ node_js:
   - "4.4.3"
 services:
   - mongodb
+addons:
+  apt:
+    sources:
+      - mongodb-upstart
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server
+      - mongodb-org-shell
+

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -68,29 +68,29 @@ BucketEntry.set('toObject', {
  * @param {Function} callback
  */
 BucketEntry.statics.create = function(data, callback) {
-  let BucketEntry = this;
+  var BucketEntry = this;
 
-  let entry = new BucketEntry({
-    bucket: data.bucket,
+  var id = storj.utils.calculateFileId(data.bucket, data.name);
+
+  var query = {
+    _id: id,
+    bucket: data.bucket
+  };
+
+  var update = {
+    _id: id,
     frame: data.frame,
-    name: data.name
-  });
+    bucket: data.bucket
+  };
 
   if (data.mimetype) {
-    entry.mimetype = data.mimetype;
+    update.mimetype = data.mimetype;
   }
 
-  // use deterministic file id based on bucketId and fileName
-  entry._id = mongoose.Types.ObjectId(
-    storj.utils.calculateFileId(data.bucket.toString(), entry.name)
-  );
+  var options = { upsert: true, 'new': true, setDefaultsOnInsert: true };
 
-  entry.save(function(err) {
+  BucketEntry.findOneAndUpdate(query, update, options, function(err, entry) {
     if (err) {
-      if (err.code === 11000) {
-        return callback(new Error('Name already used in this bucket'));
-      }
-
       return callback(err);
     }
     callback(null, entry);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-service-storage-models",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "common storage models for various storj services",
   "main": "index.js",
   "directories": {

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -50,7 +50,8 @@ describe('Storage/models/BucketEntry', function() {
         var entry = BucketEntry.create({
           frame: frame._id,
           bucket: bucket._id,
-          name: 'test.txt'
+          name: 'test.txt',
+          mimetype: 'text/plain'
         }, function(err, entry) {
           console.log(err)
           expect(entry.id).to.equal(expectedFileId);
@@ -60,7 +61,7 @@ describe('Storage/models/BucketEntry', function() {
     });
   });
 
-  it('should reject a duplicate name in this same bucket', function(done) {
+  it('should replace a duplicate name in this same bucket', function(done) {
     var frame = new Frame({
 
     });
@@ -69,9 +70,11 @@ describe('Storage/models/BucketEntry', function() {
       var entry = BucketEntry.create({
         frame: frame._id,
         bucket: expectedBucketId,
-        name: 'test.txt'
-      }, function(err){
-        expect(err.message).to.equal('Name already used in this bucket');
+        name: 'test.txt',
+        mimetype: 'text/javascript'
+      }, function(err, entry){
+        expect(err).to.equal(null);
+        expect(entry.mimetype).to.equal('text/javascript');
         done();
       });
     });


### PR DESCRIPTION
Instead of throwing an error, overwrite bucket entry with new data when the file name/ bucket id are already being used