### PR TITLE
Add exchangeStart and exchangeEnd fields and remove exchangeTime

### DIFF
--- a/lib/models/exchange-report.js
+++ b/lib/models/exchange-report.js
@@ -30,7 +30,11 @@
     type: String,
     required: true
   },
-  exchangeTime: {
+  exchangeStart: {
+    type: Date,
+    required: true
+  },
+  exchangeEnd: {
     type: Date,
     required: true
   },


### PR DESCRIPTION
Instead of pre-calculating the time elapsed we will store the start and end timestamps. 