### PR TITLE
Add `timeoutRate` to Contact

### DIFF
--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -29,12 +29,12 @@ var ContactSchema = new mongoose.Schema({
     type: Date,
     required: false
   },
-  responseTime: {
+  timeoutRate: {
     type: Number,
     required: false
   },
-  lastPingFailure: {
-    type: Date,
+  responseTime: {
+    type: Number,
     required: false
   },
   protocol: {
@@ -88,20 +88,35 @@ ContactSchema.statics.record = function(contactInfo, callback) {
 };
 
 /**
- * Will update and save the last ping failure on a contact.
- * @param {String} nodeID - The contact nodeID
- * @param {Function} callback
+ * Will update the lastTimeout and calculate the timeoutRate based
+ * on a 24 hour window of activity.
  */
-ContactSchema.statics.recordPingFailure = function(nodeID, callback) {
-  const lastPingFailure = Date.now();
-  const query = { _id: nodeID };
-  const update = {
-    $set: {
-      lastPingFailure: lastPingFailure
-    }
-  };
-  this.update(query, update, callback);
+ContactSchema.methods.recordTimeoutFailure = function() {
+  const now = Date.now();
+  const window = 86400000; // 24 hours
+  const lastTimeoutRate = this.timeoutRate || 0;
+
+  if (this.lastTimeout && this.lastTimeout > this.lastSeen) {
+    const offlineTime = now - this.lastTimeout.getTime();
+    const timeoutRate = offlineTime / window;
+
+    this.timeoutRate = Math.min(lastTimeoutRate + timeoutRate, 1);
+
+  } else if (this.lastTimeout && this.lastTimeout < this.lastSeen) {
+    const onlineTime = now - this.lastTimeout.getTime();
+    const successRate = onlineTime / window;
+
+    this.timeoutRate = Math.max(lastTimeoutRate - successRate, 0);
+  }
+
+  this.lastTimeout = now;
+
+  return this;
 };
+
+/**
+ *
+ */
 
 /**
  * Update the exponential moving average response time

--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -33,6 +33,10 @@ var ContactSchema = new mongoose.Schema({
     type: Number,
     required: false
   },
+  lastPingFailure: {
+    type: Date,
+    required: false
+  },
   protocol: {
     type: String,
     required: true
@@ -44,6 +48,8 @@ var ContactSchema = new mongoose.Schema({
 });
 
 ContactSchema.plugin(SchemaOptions);
+
+ContactSchema.index({lastSeen: 1});
 
 ContactSchema.set('toObject', {
   virtuals: true,
@@ -79,6 +85,22 @@ ContactSchema.statics.record = function(contactInfo, callback) {
     upsert: true,
     new: true
   }, done);
+};
+
+/**
+ * Will update and save the last ping failure on a contact.
+ * @param {String} nodeID - The contact nodeID
+ * @param {Function} callback
+ */
+ContactSchema.statics.recordPingFailure = function(nodeID, callback) {
+  const lastPingFailure = Date.now();
+  const query = { _id: nodeID };
+  const update = {
+    $set: {
+      lastPingFailure: lastPingFailure
+    }
+  };
+  this.update(query, update, callback);
 };
 
 /**

--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -103,7 +103,7 @@ ContactSchema.methods.recordTimeoutFailure = function() {
     this.timeoutRate = Math.min(lastTimeoutRate + timeoutRate, 1);
 
   } else if (this.lastTimeout && this.lastTimeout < this.lastSeen) {
-    const onlineTime = now - this.lastTimeout.getTime();
+    const onlineTime = this.lastSeen.getTime() - this.lastTimeout.getTime();
     const successRate = onlineTime / window;
 
     this.timeoutRate = Math.max(lastTimeoutRate - successRate, 0);

--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -115,10 +115,6 @@ ContactSchema.methods.recordTimeoutFailure = function() {
 };
 
 /**
- *
- */
-
-/**
  * Update the exponential moving average response time
  * for calls to this contact.
  * @param {Number} responseTime - Milliseconds of the response time

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mongoose-int32": "^0.1.0",
     "mongoose-types": "^1.0.3",
     "ms": "^0.7.1",
-    "storj-lib": "^6.0.0",
+    "storj-lib": "^6.0.12",
     "storj-service-error-types": "^1.0.0",
     "stripe": "^4.11.0"
   },

--- a/test/contact.unit.js
+++ b/test/contact.unit.js
@@ -126,7 +126,7 @@ describe('Storage/models/Contact', function() {
     });
 
 
-    it('0.41 after 12 hours of failure (w/ sparce success)', function() {
+    it('0.45 after 12 hours of failure (w/ sparce success)', function() {
       const clock = sandbox.useFakeTimers();
       const contact = new Contact({
         lastSeen: Date.now()
@@ -152,7 +152,7 @@ describe('Storage/models/Contact', function() {
         contact.recordTimeoutFailure();
       }
 
-      expect(contact.timeoutRate.toFixed(2)).to.equal('0.41');
+      expect(contact.timeoutRate.toFixed(2)).to.equal('0.45');
     });
 
   });

--- a/test/contact.unit.js
+++ b/test/contact.unit.js
@@ -125,7 +125,6 @@ describe('Storage/models/Contact', function() {
       expect(contact.timeoutRate.toFixed(4)).to.equal('1.0000');
     });
 
-
     it('0.45 after 12 hours of failure (w/ sparce success)', function() {
       const clock = sandbox.useFakeTimers();
       const contact = new Contact({


### PR DESCRIPTION
**Description**

The timeout rate is calculated based on a window of 24 hours. When there are two timeout failures in a row, the time between those timeouts will be counted as time offline. In the reverse, if the last seen time is more recent than the last timeout, the time since the last timeout to the last seen is considered time online *(time without a timeout failure)*.

**As part of**
- https://github.com/Storj/bridge/pull/323
- https://github.com/Storj/complex/pull/44