### PR TITLE
Give back better errors

### DIFF
--- a/lib/models/pointer.js
+++ b/lib/models/pointer.js
@@ -55,6 +55,7 @@ Pointer.methods._validate = function() {
   assert(typeof this.index === 'number', 'Invalid index supplied');
   assert(Number.isFinite(this.index), 'Invalid index supplied');
   assert(this.index >= 0, 'Invalid index supplied');
+  assert(this.hash, 'Hash is expected to be supplied');
   assert(
     Buffer(storj.utils.rmd160sha256(this.hash), 'hex').length === 20,
     'Invalid RIPEMD-160 SHA-256 hash (hex) supplied'

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -339,6 +339,12 @@ User.statics.create = function(email, passwd, callback) {
 User.statics.lookup = function(email, passwd, callback) {
   let User = this;
 
+  if (!passwd) {
+    return callback(new errors.NotAuthorizedError(
+      'Invalid email or password')
+    );
+  }
+
   User.findOne({
     _id: email,
     hashpass: crypto.createHash('sha256').update(passwd).digest('hex')

--- a/test/pointer.unit.js
+++ b/test/pointer.unit.js
@@ -54,4 +54,21 @@ describe('Storage/models/Pointer', function() {
 
   });
 
+  describe('#_validate', function() {
+
+    it('will throw hash message if missing hash', function() {
+      var shard = {
+        index: 1,
+        size: 1,
+        tree: ['tree1', 'tree2'],
+        challenges: ['challenge1', 'challenge2']
+      };
+      Pointer.create(shard, function(err) {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.match(/^Hash is expected/);
+      });
+    });
+
+  });
+
 });

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -358,6 +358,13 @@ describe('Storage/models/User', function() {
       });
     });
 
+    it('should give error if missing passwd', function(done) {
+      User.lookup('user@domain.tld', null, function(err) {
+        expect(err).to.be.instanceOf(errors.NotAuthorizedError);
+        done();
+      });
+    });
+
     it('should give a not authorized error if user not found', function(done) {
       User.lookup('user@domain.tld', sha256('password2'), function(err) {
         expect(err).to.be.instanceOf(errors.NotAuthorizedError);


### PR DESCRIPTION
hasher.update() will throw an error "Data must be a string or a buffer" with
undefined input, these checks will give back a better error when there
are undefined values that will be hashed.