### PR TITLE
Revert "Specify id for bucket entry"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,7 @@
   "undef": true,
   "unused": true,
   "maxparams": 4,
-  "maxstatements": 20,
+  "maxstatements": 14,
   "maxcomplexity": 6,
   "maxdepth": 3,
   "maxlen": 80,

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -5,17 +5,12 @@ const mongoose = require('mongoose');
 const mimetypes = require('mime-db');
 const SchemaOptions = require('../options');
 const storj = require('storj-lib');
-const errors = require('storj-service-error-types');
-const utils = storj.utils;
 
 /**
  * Represents a bucket entry that points to a file
  * @constructor
  */
 var BucketEntry = new mongoose.Schema({
-  _id: {
-    type: String
-  },
   frame: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Frame'
@@ -75,16 +70,7 @@ BucketEntry.set('toObject', {
 BucketEntry.statics.create = function(data, callback) {
   var BucketEntry = this;
 
-  let id = null;
-  if (data.id) {
-    if (data.id.length <= 64 && utils.isHexaString(data.id)) {
-      id = data.id;
-    } else {
-      return callback(new errors.BadRequestError('Invalid id supplied'));
-    }
-  } else {
-    id = storj.utils.calculateFileId(data.bucket, data.name);
-  }
+  var id = storj.utils.calculateFileId(data.bucket, data.name);
 
   var query = {
     _id: id,

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const storj = require('storj-lib');
-const errors = require('storj-service-error-types');
 const expect = require('chai').expect;
 const mongoose = require('mongoose');
 
@@ -59,49 +58,6 @@ describe('Storage/models/BucketEntry', function() {
         }, function(err, entry) {
           expect(entry.filename).to.equal('test.txt');
           expect(entry.id).to.equal(expectedFileId);
-          done();
-        });
-      });
-    });
-  });
-
-  it('should create the bucket entry with id', function(done) {
-    Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket3' },
-    function(err, bucket) {
-      var frame = new Frame({});
-      frame.save(function(err) {
-        expect(err).to.not.be.instanceOf(Error);
-        BucketEntry.create({
-          frame: frame._id,
-          bucket: bucket._id,
-          id: 'ed6c1becbcef808463e4d38b58d5d310115e42ca',
-          name: 'test2.txt',
-          mimetype: 'text/plain'
-        }, function(err, entry) {
-          expect(entry.filename).to.equal('test2.txt');
-          expect(entry.id).to.equal('ed6c1becbcef808463e4d38b58d5d310115e42ca');
-          done();
-        });
-      });
-    });
-  });
-
-  it('should NOT create the bucket entry with invalid id', function(done) {
-    Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket4' },
-    function(err, bucket) {
-      var frame = new Frame({});
-      frame.save(function(err) {
-        expect(err).to.not.be.instanceOf(Error);
-        BucketEntry.create({
-          frame: frame._id,
-          bucket: bucket._id,
-          id: '#######################################',
-          name: 'test2.txt',
-          mimetype: 'text/plain'
-        }, function(err, entry) {
-          expect(err).to.be.instanceOf(errors.BadRequestError);
-          expect(err.message).to.equal('Invalid id supplied');
-          expect(entry).to.equal(undefined);
           done();
         });
       });


### PR DESCRIPTION
Reverts Storj/service-storage-models#57

This change will require a migration from ObjectId to string for bucket entries, which will be a breaking change.