### PR TITLE
Create multikey index for contracts nodeID and store_end

### DIFF
--- a/lib/models/shard.js
+++ b/lib/models/shard.js
@@ -36,6 +36,7 @@ var ShardSchema = new mongoose.Schema({
 
 ShardSchema.index({hash: 1});
 ShardSchema.index({'contracts.nodeID': 1});
+ShardSchema.index({'contracts.contract.store_end': 1});
 
 /* jshint ignore: start */
 /* ignoring too many statements */

--- a/lib/models/shard.js
+++ b/lib/models/shard.js
@@ -35,6 +35,7 @@ var ShardSchema = new mongoose.Schema({
 });
 
 ShardSchema.index({hash: 1});
+ShardSchema.index({'contracts.nodeID': 1});
 
 /* jshint ignore: start */
 /* ignoring too many statements */

--- a/test/shard.unit.js
+++ b/test/shard.unit.js
@@ -139,4 +139,55 @@ describe('Storage/models/Shard', function() {
 
   });
 
+  describe('Indexes', function() {
+    before(function(done) {
+      const item = {
+        hash: '74f20b9ab3f2a1d6970269dde29f494d8a5895f6',
+        contracts: {
+          '2d2d9991ac279857dc72edca1d8ace90b1fce76d': {
+            store_end: 1489085649893
+          }
+        },
+        trees: {},
+        challenges: {},
+        meta: { 0: 'meta1', 1: 'meta2' }
+      };
+      Shard.create(item, done);
+    });
+
+    it('should have an index for nodeID on contracts', function(done) {
+      const query = {
+        'contracts.nodeID': '2d2d9991ac279857dc72edca1d8ace90b1fce76d',
+      };
+      const cursor = Shard.collection.find(query);
+      cursor.explain((err, result) => {
+        expect(result.queryPlanner.winningPlan.inputStage.indexBounds)
+          .to.eql({
+            'contracts.nodeID': [
+              '["2d2d9991ac279857dc72edca1d8ace90b1fce76d", ' +
+                '"2d2d9991ac279857dc72edca1d8ace90b1fce76d"]'
+            ]
+          });
+        done();
+      });
+    });
+
+    it('should have an index for store_end on contracts', function(done) {
+      const query = {
+        'contracts.contract.store_end': 1489085649893,
+      };
+      const cursor = Shard.collection.find(query);
+      cursor.explain((err, result) => {
+        expect(result.queryPlanner.winningPlan.inputStage.indexBounds)
+          .to.eql({
+            'contracts.contract.store_end': [
+              '[1489085649893.0, 1489085649893.0]'
+            ]
+          });
+        done();
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
This is necessary to lookup the contracts and shards associated with a farmer