### PR TITLE
Fix remove card

### DIFF
--- a/lib/models/payment-processor-adapters/stripe.js
+++ b/lib/models/payment-processor-adapters/stripe.js
@@ -166,10 +166,11 @@ const stripeAdapter = {
     const customerId = stripeProcessor.data.customer.id;
 
     return new Promise((resolve, reject) => {
+      console.log('ªª removing card from stripe', cardId, customerId);
       stripe.customers.deleteCard(
         customerId,
         cardId,
-        function(err) {
+        function(err, confirmation) {
           if (err) {
             console.error('Error deleting card from stripe:', err);
             return reject(err);
@@ -177,15 +178,14 @@ const stripeAdapter = {
 
           stripe.customers.retrieve(customerId, (err, customer) => {
             if (err) {
-              console.error('removePaymentMethod', err);
+              console.error(' •• removePaymentMethod', err);
               return reject(err);
             }
-
             stripeProcessor.data.customer = customer;
 
-            return stripeProcessor.save()
-              .then(resolve);
+            stripeProcessor.save().then(() => resolve(true));
           });
+
         }
       );
     });

--- a/lib/models/payment-processor-adapters/stripe.js
+++ b/lib/models/payment-processor-adapters/stripe.js
@@ -166,11 +166,11 @@ const stripeAdapter = {
     const customerId = stripeProcessor.data.customer.id;
 
     return new Promise((resolve, reject) => {
-      console.log('ªª removing card from stripe', cardId, customerId);
+      console.log('Removing card from stripe', cardId, customerId);
       stripe.customers.deleteCard(
         customerId,
         cardId,
-        function(err, confirmation) {
+        function(err) {
           if (err) {
             console.error('Error deleting card from stripe:', err);
             return reject(err);
@@ -178,7 +178,7 @@ const stripeAdapter = {
 
           stripe.customers.retrieve(customerId, (err, customer) => {
             if (err) {
-              console.error(' •• removePaymentMethod', err);
+              console.error('removePaymentMethod', err);
               return reject(err);
             }
             stripeProcessor.data.customer = customer;

--- a/lib/models/payment-processor.js
+++ b/lib/models/payment-processor.js
@@ -82,12 +82,12 @@ PaymentProcessorSchema.pre('validate', function(next) {
     .find({ user: this.user, payment_processor: this.payment_processor })
     .then((paymentProcessors) => {
       const err = new errors.BadRequestError(
-        `There can only be one payment processor per vendor per user; 
+        `There can only be one payment processor per vendor per user;
         payment_processor: ${this.payment_processor}
         user: ${this.user}`
       );
 
-      return (paymentProcessors.length > 0) ? next(err) : next(null);
+      return (paymentProcessors.length > 1) ? next(err) : next(null);
     });
 });
 


### PR DESCRIPTION
Calls the `resolve()` method to complete the Promise for `removePaymentMethod`. 

Fixes a validation method for `paymentProcessors`. It was incorrectly calling an error for payment processors. A user can have none or one payment processor for vendor, but no more. The validation was erroring if there was one or more payment processor, instead of letting one payment processor pass.