### PR TITLE
Have the configuration options be how limits are handled

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -208,11 +208,9 @@ UserSchema.methods.recordDownloadBytes = function(bytes, callback) {
  * @returns {Boolean}
  */
 UserSchema.methods._isRateLimited = function(hourlyB, dailyB, monthlyB, prop) {
-  return this.isFreeTier ?
-      (this[prop].lastHourBytes >= hourlyB) ||
-      (this[prop].lastDayBytes >= dailyB) ||
-      (this[prop].lastMonthBytes >= monthlyB)
-    : false;
+  return (this[prop].lastHourBytes >= hourlyB) ||
+    (this[prop].lastDayBytes >= dailyB) ||
+    (this[prop].lastMonthBytes >= monthlyB);
 };
 
 /**

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -264,12 +264,6 @@ describe('Storage/models/User', function() {
     });
     after(() => clock.restore());
 
-    it('should return false in paid tier', function() {
-      expect(userPaid.isDownloadRateLimited(10, 20, 30)).to.equal(false);
-      userPaid.recordDownloadBytes(700);
-      expect(userPaid.isDownloadRateLimited(10, 20, 30)).to.equal(false);
-    });
-
     it('should return false if under the limits', function() {
       expect(userFree.isDownloadRateLimited(10, 20, 30)).to.equal(false);
       userFree.recordDownloadBytes(10);
@@ -395,12 +389,6 @@ describe('Storage/models/User', function() {
       });
     });
     after(() => clock.restore());
-
-    it('should return false in paid tier', function() {
-      expect(userPaid.isUploadRateLimited(10, 20, 30)).to.equal(false);
-      userPaid.recordUploadBytes(700);
-      expect(userPaid.isUploadRateLimited(10, 20, 30)).to.equal(false);
-    });
 
     it('should return false if under the limits', function() {
       expect(userFree.isUploadRateLimited(10, 20, 30)).to.equal(false);


### PR DESCRIPTION
To enable an user to have different limits, those limits should be
passed into the `isDownloadRateLimited` and `isUploadRateLimited`
functions.