### PR TITLE
Add STORJ_EVENT constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,7 +21,8 @@ module.exports = {
     NEW_SIGNUP: 'new-signup',
     REFERRAL_RECIPIENT: 'referral-recipient',
     REFERRAL_SENDER: 'referral-sender',
-    FREE_THRESHOLD: 'free-threshold'
+    FREE_THRESHOLD: 'free-threshold',
+    STORJ_EVENT: 'storj-event'
   },
   PROMO_EXPIRES: {
     'DEFAULT': setPromoExpiration(1, 'year'),


### PR DESCRIPTION
Adds `STORJ_EVENT` constant for when we have events and manually issue credits. Does not need a corresponding `promo_amount` or `promo_expires` because it will vary depending on the event. 