### PR TITLE
Add uuid to user model

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 const { isValidEmail } = require('../utils');
+const uuid = require('uuid/v4');
 
 /**
  * Represents a user
@@ -20,6 +21,11 @@ var UserSchema = new mongoose.Schema({
       validator: value => isValidEmail(value),
       message: 'Invalid user email address'
     }
+  },
+  uuid: {
+    type: String,
+    required: true,
+    default: uuid
   },
   hashpass: {
     type: String,

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -8,6 +8,7 @@ const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 const { isValidEmail } = require('../utils');
 const uuid = require('uuid/v4');
+const validateUUID = require('uuid-validate');
 
 /**
  * Represents a user
@@ -25,7 +26,11 @@ var UserSchema = new mongoose.Schema({
   uuid: {
     type: String,
     required: true,
-    default: uuid
+    default: uuid,
+    validate: {
+      validator: value => validateUUID(value, 4),
+      message: 'Invalid UUID'
+    }
   },
   hashpass: {
     type: String,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "random-word": "^2.0.0",
     "storj-lib": "^6.1.2",
     "storj-service-error-types": "^1.1.0",
-    "stripe": "^4.11.0"
+    "stripe": "^4.11.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "async": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "storj-lib": "^6.1.2",
     "storj-service-error-types": "^1.1.0",
     "stripe": "^4.11.0",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "uuid-validate": "^0.0.2"
   },
   "devDependencies": {
     "async": "^2.0.1",

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -161,7 +161,7 @@ describe('Storage/models/User', function() {
         }
         const keys = Object.keys(user.toObject());
         expect(keys).to.contain(
-          'isFreeTier', 'activated', 'created', 'email', 'id'
+          'isFreeTier', 'activated', 'created', 'email', 'id', 'uuid'
         );
         expect(keys).to.not.contain(
           '__v', '_id', 'hashpass', 'activator', 'deactivator', 'resetter',

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -67,7 +67,6 @@ describe('Storage/models/User', function() {
 
     it('should create a valid UUID', function(done) {
       User.create('uuid@domain.tld', sha256('password'), function(err, user) {
-        expect(user.uuid).to.be.ok;
         expect(validateUUID(user.uuid)).to.equal(true);
         done();
       });

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -9,6 +9,7 @@ const { expect } = require('chai');
 const mongoose = require('mongoose');
 const sinon = require('sinon');
 const ms = require('ms');
+const validateUUID = require('uuid-validate');
 
 require('mongoose-types').loadTypes(mongoose);
 
@@ -60,6 +61,14 @@ describe('Storage/models/User', function() {
       User.create('wrong@', sha256('password'), function(err) {
         expect(err).to.be.instanceOf(Error);
         expect(err.message).to.equal('Invalid email');
+        done();
+      });
+    });
+
+    it('should create a valid UUID', function(done) {
+      User.create('uuid@domain.tld', sha256('password'), function(err, user) {
+        expect(user.uuid).to.be.ok;
+        expect(validateUUID(user.uuid)).to.equal(true);
         done();
       });
     });


### PR DESCRIPTION
Adds a UUID to the user model.

Purposes:
Add non-email unique identifier.
Allow continuity if user changes email address.
Allows use of non-identifiable info on 3rd party services.

- [X] Add UUID field
- [X] Autopopulate
- [X] Validate
- [X] Test