### PR TITLE
Deprecate deterministic bucket_id and file_id

### DIFF
--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -56,6 +56,7 @@ Bucket.plugin(SchemaOptions);
 
 Bucket.index({ user: 1 });
 Bucket.index({ created: 1 });
+Bucket.index({ user: 1, name: 1 }, { unique: true });
 
 Bucket.set('toObject', {
   transform: function(doc, ret) {

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const storj = require('storj-lib');
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 const crypto = require('crypto');
@@ -85,6 +86,14 @@ Bucket.statics.create = function(user, data, callback) {
   if (data.name) {
     bucket.name = data.name;
   }
+
+  // XXX THIS WILL BE DEPRECATED IN THE NEXT MAJOR RELEASE
+  // XXX Make sure to update any code that depends on this being
+  // XXX based on the name as soon as possible. Once this is
+  // XXX deprecated the id will be a unique ObjectId
+  bucket._id = mongoose.Types.ObjectId(
+    storj.utils.calculateBucketId(user._id, bucket.name)
+  );
 
   bucket.save(function(err) {
     if (err) {

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -2,7 +2,6 @@
 
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
-const storj = require('storj-lib');
 const crypto = require('crypto');
 /**
  * Represents a storage bucket
@@ -85,10 +84,6 @@ Bucket.statics.create = function(user, data, callback) {
   if (data.name) {
     bucket.name = data.name;
   }
-
-  bucket._id = mongoose.Types.ObjectId(
-    storj.utils.calculateBucketId(user._id, bucket.name)
-  );
 
   bucket.save(function(err) {
     if (err) {

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -57,7 +57,6 @@ Bucket.plugin(SchemaOptions);
 
 Bucket.index({ user: 1 });
 Bucket.index({ created: 1 });
-Bucket.index({ user: 1, name: 1 }, { unique: true });
 
 Bucket.set('toObject', {
   transform: function(doc, ret) {

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -85,7 +85,6 @@ BucketEntry.virtual('filename').get(function() {
 BucketEntry.index({ bucket: 1 });
 BucketEntry.index({ created: 1 });
 BucketEntry.index({ index: 1 }, { unique: true, sparse: true});
-BucketEntry.index({ bucket: 1, name: 1 }, { unique: true });
 
 BucketEntry.plugin(SchemaOptions, {
   read: 'secondaryPreferred'

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -92,7 +92,7 @@ BucketEntry.set('toObject', {
 BucketEntry.statics.create = function(data, callback) {
   var BucketEntry = this;
 
-  var id = storj.utils.calculateFileId(data.bucket, data.name);
+  var id = storj.utils.calculateFileId(data.bucket, data.frame);
 
   var query = {
     _id: id,

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -78,6 +78,7 @@ BucketEntry.virtual('filename').get(function() {
 BucketEntry.index({ bucket: 1 });
 BucketEntry.index({ created: 1 });
 BucketEntry.index({ index: 1 }, { unique: true, sparse: true});
+BucketEntry.index({ bucket: 1, name: 1 }, { unique: true });
 
 BucketEntry.plugin(SchemaOptions, {
   read: 'secondaryPreferred'

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -11,11 +11,22 @@ const errors = require('storj-service-error-types');
 const hmactypes = ['sha512', 'sha256', 'ripemd160'];
 const erasuretypes = ['reedsolomon'];
 
+function isValidIndex(index) {
+  return index && index.length === 64 && utils.isHexaString(index);
+}
+
 /**
  * Represents a bucket entry that points to a file
  * @constructor
  */
 var BucketEntry = new mongoose.Schema({
+  index: {
+    type: String,
+    validate: {
+      validator: (value) => isValidIndex(value),
+      message: 'Invalid index'
+    }
+  },
   frame: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Frame'
@@ -66,6 +77,7 @@ BucketEntry.virtual('filename').get(function() {
 
 BucketEntry.index({ bucket: 1 });
 BucketEntry.index({ created: 1 });
+BucketEntry.index({ index: 1 }, { unique: true, sparse: true});
 
 BucketEntry.plugin(SchemaOptions, {
   read: 'secondaryPreferred'
@@ -92,26 +104,25 @@ BucketEntry.set('toObject', {
 BucketEntry.statics.create = function(data, callback) {
   var BucketEntry = this;
 
-  var id = storj.utils.calculateFileId(data.bucket, data.frame);
-
-  var query = {
-    _id: id,
-    bucket: data.bucket
-  };
-
-  var update = {
-    _id: id,
+  let doc = {
     frame: data.frame,
     bucket: data.bucket,
     name: data.name
   };
+
+  if (!isValidIndex(data.index)) {
+    return callback(new Error('Invalid index, expected to be 256 hex string, ' +
+                              'please make sure to have the latest client'));
+  } else {
+    doc.index = data.index;
+  }
 
   if (data.mimetype) {
     if (Object.keys(mimetypes).indexOf(data.mimetype) === -1) {
       return callback(new Error('Invalid mimetype supplied'));
     }
 
-    update.mimetype = data.mimetype;
+    doc.mimetype = data.mimetype;
   }
 
   if (data.hmac) {
@@ -127,7 +138,7 @@ BucketEntry.statics.create = function(data, callback) {
       return callback(new errors.BadRequestError('Invalid hmac value'));
 
     }
-    update.hmac = data.hmac;
+    doc.hmac = data.hmac;
   }
 
   if (data.erasure) {
@@ -136,21 +147,13 @@ BucketEntry.statics.create = function(data, callback) {
         erasuretypes.indexOf(data.erasure.type) === -1) {
       return callback(new errors.BadRequestError('Invalid erasure type'));
     }
-    update.erasure = {
+    doc.erasure = {
       type: data.erasure.type
     };
   }
 
-  var options = { upsert: true, 'new': true, setDefaultsOnInsert: true };
-
-  BucketEntry.findOneAndUpdate(query, update, options, function(err, entry) {
-    if (err) {
-      return callback(err);
-    }
-
-    callback(null, entry);
-  });
-
+  const entry = new BucketEntry(doc);
+  entry.save(callback);
 };
 
 module.exports = function(connection) {

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -12,7 +12,14 @@ const hmactypes = ['sha512', 'sha256', 'ripemd160'];
 const erasuretypes = ['reedsolomon'];
 
 function isValidIndex(index) {
-  return index && index.length === 64 && utils.isHexaString(index);
+  // XXX DEPRECATION IN NEXT MAJOR RELEASE
+  // XXX The determinitic id will be deprecated and the index field will
+  // XXX become required for any new bucket entries. This is to make sure
+  // XXX that each bucket entry will have a unique id.
+  if (index) {
+    return index.length === 64 && utils.isHexaString(index);
+  }
+  return true;
 }
 
 /**
@@ -105,15 +112,21 @@ BucketEntry.set('toObject', {
 BucketEntry.statics.create = function(data, callback) {
   var BucketEntry = this;
 
+  // XXX DEPRECATION IN NEXT MAJOR RELEASE
+  // XXX The determinitic id will be deprecated and the index field will
+  // XXX become required for any new bucket entries. This is to make sure
+  // XXX that each bucket entry will have a unique id.
+  const id = storj.utils.calculateFileId(data.bucket, data.name);
+
   let doc = {
+    _id: id,
     frame: data.frame,
     bucket: data.bucket,
     name: data.name
   };
 
   if (!isValidIndex(data.index)) {
-    return callback(new Error('Invalid index, expected to be 256 hex string, ' +
-                              'please make sure to have the latest client'));
+    return callback(new Error('Invalid index, expected to be 256 hex string'));
   } else {
     doc.index = data.index;
   }

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -33,6 +33,11 @@ describe('Storage/models/Bucket', function() {
   describe('#create', function() {
 
     it('should create the bucket with the default props', function(done) {
+
+      // XXX DEPRECATED IN THE NEXT MAJOR RELEASE
+      var expectedBucketId =
+        storj.utils.calculateBucketId('user@domain.tld', 'New Bucket');
+
       Bucket.create(
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
@@ -45,6 +50,10 @@ describe('Storage/models/Bucket', function() {
           expect(bucket.publicPermissions.length).to.equal(0);
           Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
             expect(err).to.not.be.instanceOf(Error);
+
+            // XXX DEPRECATED IN THE NEXT MAJOR RELEASE
+            expect(bucket.id).to.equal(expectedBucketId);
+
             expect(bucket.id.length).to.equal(24);
             expect(bucket.name).to.equal('New Bucket');
             expect(bucket.storage).to.equal(0);

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -33,22 +33,19 @@ describe('Storage/models/Bucket', function() {
   describe('#create', function() {
 
     it('should create the bucket with the default props', function(done) {
-      var expectedBucketId =
-        storj.utils.calculateBucketId('user@domain.tld', 'New Bucket');
-
       Bucket.create(
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
         function(err, bucket) {
           expect(err).to.not.be.instanceOf(Error);
-          expect(bucket.id).to.equal(expectedBucketId);
+          expect(bucket.id.length).to.equal(24);
           expect(bucket.name).to.equal('New Bucket');
           expect(bucket.storage).to.equal(0);
           expect(bucket.transfer).to.equal(0);
           expect(bucket.publicPermissions.length).to.equal(0);
           Bucket.findOne({ _id: bucket.id }, function(err, bucket) {
             expect(err).to.not.be.instanceOf(Error);
-            expect(bucket.id).to.equal(expectedBucketId);
+            expect(bucket.id.length).to.equal(24);
             expect(bucket.name).to.equal('New Bucket');
             expect(bucket.storage).to.equal(0);
             expect(bucket.transfer).to.equal(0);
@@ -85,12 +82,14 @@ describe('Storage/models/Bucket', function() {
       });
     });
 
-    it('should reject a duplicate name', function(done) {
+    it('should not reject a duplicate name', function(done) {
       Bucket.create(
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
         function(err) {
-          expect(err.message).to.equal('Name already used by another bucket');
+          if (err) {
+            return done(err);
+          }
           done();
       });
     });

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -82,14 +82,12 @@ describe('Storage/models/Bucket', function() {
       });
     });
 
-    it('should not reject a duplicate name', function(done) {
+    it('should reject a duplicate name', function(done) {
       Bucket.create(
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
         function(err) {
-          if (err) {
-            return done(err);
-          }
+          expect(err.message).to.equal('Name already used by another bucket');
           done();
       });
     });

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -108,9 +108,9 @@ describe('Storage/models/BucketEntry', function() {
         bucket: expectedBucketId,
         name: 'test.txt',
         mimetype: 'text/javascript'
-      }, function(err, entry){
-        expect(err).to.equal(null);
-        expect(entry.mimetype).to.equal('text/javascript');
+      }, function(err){
+        expect(err).to.be.instanceOf(Error);
+        expect(err.code).to.equal(11000);
         done();
       });
     });

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -44,6 +44,10 @@ describe('Storage/models/BucketEntry', function() {
   var expectedBucketId =
     storj.utils.calculateBucketId('user@domain.tld', 'New Bucket2');
 
+  // XXX DEPRECATED IN THE NEXT MAJOR RELEASE
+  var expectedFileId =
+    storj.utils.calculateFileId(expectedBucketId, 'test.txt');
+
   it('should create the bucket entry metadata', function(done) {
     const index = crypto.randomBytes(32).toString('hex');
     Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket2' },
@@ -67,6 +71,10 @@ describe('Storage/models/BucketEntry', function() {
           expect(entry.erasure.type).to.equal('reedsolomon');
           expect(entry.index).to.equal(index);
           expect(entry.filename).to.equal('test.txt');
+
+          // XXX DEPRECATED IN THE NEXT MAJOR RELEASE
+          expect(entry.id).to.equal(expectedFileId);
+
           expect(entry.id.length).to.equal(24);
           done();
         });

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -45,14 +45,14 @@ describe('Storage/models/BucketEntry', function() {
     storj.utils.calculateBucketId('user@domain.tld', 'New Bucket2');
 
   it('should create the bucket entry metadata', function(done) {
+    const index = crypto.randomBytes(32).toString('hex');
     Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket2' },
-    function(err, bucket) {
+                  function(err, bucket) {
       var frame = new Frame({});
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
-        var expectedFileId =
-            storj.utils.calculateFileId(expectedBucketId, frame._id);
         BucketEntry.create({
+          index: index,
           frame: frame._id,
           bucket: bucket._id,
           name: 'test.txt',
@@ -65,8 +65,9 @@ describe('Storage/models/BucketEntry', function() {
             return done(err);
           }
           expect(entry.erasure.type).to.equal('reedsolomon');
+          expect(entry.index).to.equal(index);
           expect(entry.filename).to.equal('test.txt');
-          expect(entry.id).to.equal(expectedFileId);
+          expect(entry.id.length).to.equal(24);
           done();
         });
       });
@@ -102,6 +103,7 @@ describe('Storage/models/BucketEntry', function() {
     frame.save(function(err) {
       expect(err).to.not.be.instanceOf(Error);
       BucketEntry.create({
+        index: crypto.randomBytes(32).toString('hex'),
         frame: frame._id,
         bucket: expectedBucketId,
         name: 'test.txt',
@@ -120,6 +122,7 @@ describe('Storage/models/BucketEntry', function() {
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           mimetype: 'invalid/mimetype',
           bucket: bucket._id,
@@ -140,6 +143,7 @@ describe('Storage/models/BucketEntry', function() {
           return done(err);
         }
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           bucket: bucket._id,
           name: 'test-with-hmac.txt',
@@ -173,6 +177,7 @@ describe('Storage/models/BucketEntry', function() {
           return done(err);
         }
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           bucket: bucket._id,
           name: 'test-with-hmac.txt',
@@ -198,6 +203,7 @@ describe('Storage/models/BucketEntry', function() {
           return done(err);
         }
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           bucket: bucket._id,
           name: 'test-with-hmac.txt',
@@ -221,6 +227,7 @@ describe('Storage/models/BucketEntry', function() {
           return done(err);
         }
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           bucket: bucket._id,
           name: 'test-with-hmac.txt',
@@ -242,6 +249,7 @@ describe('Storage/models/BucketEntry', function() {
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
         BucketEntry.create({
+          index: crypto.randomBytes(32).toString('hex'),
           frame: frame._id,
           mimetype: 'text/javascript',
           bucket: bucket._id,
@@ -275,6 +283,7 @@ describe('Storage/models/BucketEntry', function() {
             return done(err);
           }
           BucketEntry.create({
+            index: crypto.randomBytes(32).toString('hex'),
             frame: frame._id,
             mimetype: 'text/javascript',
             bucket: bucket._id,

--- a/test/bucketentry.unit.js
+++ b/test/bucketentry.unit.js
@@ -43,8 +43,6 @@ describe('Storage/models/BucketEntry', function() {
 
   var expectedBucketId =
     storj.utils.calculateBucketId('user@domain.tld', 'New Bucket2');
-  var expectedFileId =
-    storj.utils.calculateFileId(expectedBucketId, 'test.txt');
 
   it('should create the bucket entry metadata', function(done) {
     Bucket.create({ _id: 'user@domain.tld' }, { name: 'New Bucket2' },
@@ -52,6 +50,8 @@ describe('Storage/models/BucketEntry', function() {
       var frame = new Frame({});
       frame.save(function(err) {
         expect(err).to.not.be.instanceOf(Error);
+        var expectedFileId =
+            storj.utils.calculateFileId(expectedBucketId, frame._id);
         BucketEntry.create({
           frame: frame._id,
           bucket: bucket._id,


### PR DESCRIPTION
**Motivation**:
- Will give historically unique entry id if the same bucket entry name is used within the same bucket over time, and helps simplify billing logic.
- The same encryption key and iv will not be reused if the same bucket entry name is used w/ a different file, better security practices.
- Restores the ability to rename buckets and bucket entries *(file_id, bucket_id, and encryption_key are no longer derived from the name)*
- Generally helps to uniquely identify bucket entries

**Upgrading**:
- **The bucket entry id will *initially* remain as-is, and will be deprecated in the next major release. This is to introduce bucket entry `index` before deprecation.**
- Backwards compatible for downloads as `file_id` or `index` can be used to determine derivation of encryption key for the file. Those with the `index` field will use the new method.
- Older clients will need to upgrade to upload new files, an error is given to indicate that this is necessary to avoid any confusion.

**Other Notes**:
- Bucket entry creation can be made idempotent, such that it will be possible to detect if there is a duplicate, based on unique key `index`, and to not repeat the same action (e.g. storage events).
~~- Adds index to buckets for `user:name` to keep uniqueness of bucket names and to be able to query by bucket name efficiently~~
~~- Adds index to bucket entries for `bucket:name` to keep uniqueness of bucket entry names within a bucket~~

**Related**:
- https://github.com/Storj/bridge/issues/405
- https://github.com/Storj/bridge/issues/406

**Todo**:
- [x] Update clients to use bucket entry `index` when deriving encryption key https://github.com/Storj/libstorj/pull/286