### PR TITLE
Add preferences to the user model, and a dnt preference

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -67,6 +67,13 @@ var UserSchema = new mongoose.Schema({
     type: Boolean,
     default: true
   },
+  preferences: {
+    dnt: {
+      type: Boolean,
+      default: false,
+      required: true
+    }
+  },
   bytesUploaded: {
     lastHourStarted: {
       type: Date,

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -72,6 +72,13 @@ describe('Storage/models/User', function() {
       });
     });
 
+    it('should add a dnt preference', function(done) {
+      User.create('dnt@domain.tld', sha256('password'), function(err, user) {
+        expect(user.preferences.dnt).to.equal(false);
+        done();
+      });
+    });
+
     it('should not create a user account with bad password', function(done) {
       User.create('wrong@domain.tld', 'password', function(err) {
         expect(err.message).to.equal(


### PR DESCRIPTION
Goal: add a do not track preference to the user model for use with analytics. A preference on the user model allows users to set a single preference to disable tracking on every client. 

Bridge update required to allow users to set their DNT preference. 