### PR TITLE
Add default logger to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,16 @@ function Storage(mongoURI, mongoOptions, storageOptions) {
 
   this._uri = mongoURI;
   this._options = mongoOptions;
-  this._log = storageOptions ? (storageOptions.logger || console) : console;
+
+  const defaultLogger = {
+    info: console.log,
+    debug: console.log,
+    error: console.error,
+    warn: console.log
+  };
+  this._log = storageOptions ?
+    (storageOptions.logger || defaultLogger) : defaultLogger;
+
   this.connection = this._connect();
   this.models = this._createBoundModels();
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function Storage(mongoURI, mongoOptions, storageOptions) {
     info: console.log,
     debug: console.log,
     error: console.error,
-    warn: console.log
+    warn: console.warn
   };
   this._log = storageOptions ?
     (storageOptions.logger || defaultLogger) : defaultLogger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-service-storage-models",
-  "version": "8.16.0",
+  "version": "8.16.1",
   "description": "common storage models for various storj services",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-service-storage-models",
-  "version": "8.15.0",
+  "version": "8.16.0",
   "description": "common storage models for various storj services",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Fixes bug introduced by #91. The logger would default to `console`, and error when `console.debug` was called.