### PR TITLE
Add unique indexes for bucket name and bucket entry name

### DIFF
--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -57,6 +57,7 @@ Bucket.plugin(SchemaOptions);
 
 Bucket.index({ user: 1 });
 Bucket.index({ created: 1 });
+Bucket.index({ user: 1, name: 1 }, { unique: true });
 
 Bucket.set('toObject', {
   transform: function(doc, ret) {

--- a/lib/models/bucketentry.js
+++ b/lib/models/bucketentry.js
@@ -85,6 +85,7 @@ BucketEntry.virtual('filename').get(function() {
 BucketEntry.index({ bucket: 1 });
 BucketEntry.index({ created: 1 });
 BucketEntry.index({ index: 1 }, { unique: true, sparse: true});
+BucketEntry.index({ bucket: 1, name: 1 }, { unique: true });
 
 BucketEntry.plugin(SchemaOptions, {
   read: 'secondaryPreferred'

--- a/migration/duplicate-bucketnames.js
+++ b/migration/duplicate-bucketnames.js
@@ -1,0 +1,29 @@
+var uniqueBucketNames = function() {
+  db.buckets.aggregate([
+    {
+      $group: {
+        _id: {
+          userName: "$user",
+          bucketName: "$name"
+        },
+        duplicates: {$push: "$_id"},        
+        count: {$sum: 1}
+      }
+    },
+    {
+      $match: {
+        count: {$gt: 1}
+      }
+    }], {allowDiskUse: true}).forEach((data) => {
+      for (var i = 0; i < data.duplicates.length; i++) {
+        var id = data.duplicates[i];
+        var name = data._id.bucketName + ' (' + i + ')';
+        print("updating id: " + id + " original: " + data._id.bucketName + " to name: " + name);
+        db.buckets.update({ _id: id }, { $set: {name: name} }, (err, result) => {
+          print(err || result);
+        })
+      }      
+    })
+};
+
+uniqueBucketNames();

--- a/migration/duplicate-filenames.js
+++ b/migration/duplicate-filenames.js
@@ -1,0 +1,30 @@
+var uniqueBucketEntryNames = function() {
+  db.bucketentries.aggregate([
+    {
+      $group: {
+        _id: {
+          bucketId: "$bucket",
+          fileName: "$name"
+        },
+        duplicates: {$push: "$_id"},
+        count: {$sum: 1}
+      }
+    },
+    {
+      $match: {
+        count: {$gt: 1}
+      }
+    }], {allowDiskUse: true}).forEach((data) => {
+
+      for (var i = 0; i < data.duplicates.length; i++) {
+        var id = data.duplicates[i];
+        var name = data._id.fileName + ' (' + i + ')';
+        print("updating id: " + id + " original: " + data._id.fileName + " to name: " + name);
+        db.bucketentries.update({ _id: id }, { $set: {name: name} }, (err, result) => {
+          print(err || result);
+        })
+      }
+    })
+};
+
+uniqueBucketEntryNames();


### PR DESCRIPTION
This is for the benefit of applications so as to avoid unresolvable ambiguities when there are duplicate names. This will require a migration script to handle any existing duplicates.

Part of: https://github.com/Storj/bridge/pull/435
