### PR TITLE
Fix frame calculated sizes

### DIFF
--- a/lib/models/frame.js
+++ b/lib/models/frame.js
@@ -71,28 +71,47 @@ Frame.methods.unlock = function(callback) {
 };
 
 Frame.methods.addShard = function(pointer, callback) {
+  const self = this;
 
-  let replaced = false;
-  let update = {};
-
-  for (let i = 0; i < this.shards.length; i++) {
-    if (this.shards[i].index === pointer.index) {
-      update.$pull = { shards: this.shards[i]._id };
-      replaced = true;
-      break;
-    }
-  }
-
-  if (!replaced) {
+  function pushShard(next) {
+    let update = {};
     update.$inc = { storageSize: pointer.size };
     if (!pointer.parity) {
       update.$inc.size = pointer.size;
     }
+    update.$push = { shards: pointer._id };
+    self.update(update, next);
   }
 
-  update.$push = { shards: pointer._id };
+  function maybePullShard(next) {
+    let replaced = false;
+    let pullUpdate = {};
 
-  this.update(update, callback);
+    for (let i = 0; i < self.shards.length; i++) {
+      if (self.shards[i].index === pointer.index) {
+        pullUpdate.$pull = { shards: self.shards[i]._id };
+        replaced = true;
+        break;
+      }
+    }
+
+    if (replaced) {
+      pullUpdate.$inc = { storageSize: -1 * pointer.size };
+      if (!pointer.parity) {
+        pullUpdate.$inc.size = -1 * pointer.size;
+      }
+      self.update(pullUpdate, next);
+    } else {
+      next();
+    }
+  }
+
+  maybePullShard((err) => {
+    if (err) {
+      return callback(err);
+    }
+    pushShard(callback);
+  });
 };
 
 /**

--- a/lib/models/frame.js
+++ b/lib/models/frame.js
@@ -29,6 +29,10 @@ var Frame = new mongoose.Schema({
     type: Number,
     default: 0
   },
+  storageSize: {
+    type: Number,
+    default: 0
+  },
   shards: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Pointer'
@@ -64,6 +68,31 @@ Frame.methods.unlock = function(callback) {
   this.locked = false;
 
   this.save(callback);
+};
+
+Frame.methods.addShard = function(pointer, callback) {
+
+  let replaced = false;
+  let update = {};
+
+  for (let i = 0; i < this.shards.length; i++) {
+    if (this.shards[i].index === pointer.index) {
+      update.$pull = { shards: this.shards[i]._id };
+      replaced = true;
+      break;
+    }
+  }
+
+  if (!replaced) {
+    update.$inc = { storageSize: pointer.size };
+    if (!pointer.parity) {
+      update.$inc.size = pointer.size;
+    }
+  }
+
+  update.$push = { shards: pointer._id };
+
+  this.update(update, callback);
 };
 
 /**


### PR DESCRIPTION
- `frame.size` will be original expected size of the file
- `frame.storageSize` will be the size of the file with erasure encoding
- Fixes size bug when multiple shards are added to the frame concurrently

Part of: https://github.com/Storj/bridge/pull/442