### PR TITLE
Lower min shard size to 15k

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -52,7 +52,7 @@ module.exports = {
     BANDWIDTH: 'bandwidth',
     OTHER: 'adjustment'
   },
-  MIN_SHARD_SIZE: 2097152,
+  MIN_SHARD_SIZE: 15360,
   LOG_LEVEL_NONE: 0,
   LOG_LEVEL_ERROR: 1,
   LOG_LEVEL_WARN: 2,


### PR DESCRIPTION
The average meta data for storage is around:
- 25 mirrors at 440 bytes
- 1 pointer at 490 bytes
- 1 shard at 2857 bytes

Plus the frame and bucket entry for the file
- 1 frame 58 bytes
- 1 bucket entry 285 bytes