### PR TITLE
Fix bug with checking rate limit

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -277,10 +277,27 @@ UserSchema.methods.recordDownloadBytes = function(bytes, callback) {
  * @returns {Boolean}
  */
 UserSchema.methods._isRateLimited = function(hourlyB, dailyB, monthlyB, prop) {
+  const now = Date.now();
+
+  let {lastHourStarted, lastDayStarted, lastMonthStarted} = this[prop];
+  let {lastHourBytes, lastDayBytes, lastMonthBytes} = this[prop];
+
+  if (now - lastHourStarted >= ms('1h')) {
+    lastHourBytes = 0;
+  }
+
+  if (now - lastDayStarted >= ms('24h')) {
+    lastDayBytes = 0;
+  }
+
+  if (now - lastMonthStarted >= ms('30d')) {
+    lastMonthBytes = 0;
+  }
+
   return this.isFreeTier ?
-      (this[prop].lastHourBytes >= hourlyB) ||
-      (this[prop].lastDayBytes >= dailyB) ||
-      (this[prop].lastMonthBytes >= monthlyB)
+    (lastHourBytes >= hourlyB) ||
+    (lastDayBytes >= dailyB) ||
+    (lastMonthBytes >= monthlyB)
     : false;
 };
 
@@ -289,7 +306,6 @@ UserSchema.methods._isRateLimited = function(hourlyB, dailyB, monthlyB, prop) {
  * @returns {Boolean}
  */
 UserSchema.methods.isUploadRateLimited = function(hourlyB, dailyB, monthlyB) {
-  this.recordUploadBytes(0); // NB: Trigger reset if needed
   return this._isRateLimited(hourlyB, dailyB, monthlyB, 'bytesUploaded');
 };
 
@@ -298,7 +314,6 @@ UserSchema.methods.isUploadRateLimited = function(hourlyB, dailyB, monthlyB) {
  * @returns {Boolean}
  */
 UserSchema.methods.isDownloadRateLimited = function(hourlyB, dailyB, monthlyB) {
-  this.recordDownloadBytes(0); // NB: Trigger reset if needed
   return this._isRateLimited(hourlyB, dailyB, monthlyB, 'bytesDownloaded');
 };
 

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -426,7 +426,11 @@ describe('Storage/models/User', function() {
             expect(user.bytesUploaded.lastDayBytes).to.equal(4096);
             expect(user.bytesUploaded.lastMonthBytes).to.equal(4096);
 
+            expect(user.isUploadRateLimited(1000, 8000, 16000)).to.equal(true);
+
             clock.tick(ms('2h'));
+
+            expect(user.isUploadRateLimited(1000, 8000, 16000)).to.equal(false);
 
             user.recordUploadBytes(1, (err) => {
               if (err) {

--- a/test/user.unit.js
+++ b/test/user.unit.js
@@ -427,10 +427,14 @@ describe('Storage/models/User', function() {
             expect(user.bytesUploaded.lastMonthBytes).to.equal(4096);
 
             expect(user.isUploadRateLimited(1000, 8000, 16000)).to.equal(true);
+            expect(user.isUploadRateLimited(8000, 1000, 16000)).to.equal(true);
+            expect(user.isUploadRateLimited(8000, 8000, 1000)).to.equal(true);
 
             clock.tick(ms('2h'));
 
             expect(user.isUploadRateLimited(1000, 8000, 16000)).to.equal(false);
+            expect(user.isUploadRateLimited(8000, 1000, 16000)).to.equal(false);
+            expect(user.isUploadRateLimited(8000, 8000, 1000)).to.equal(false);
 
             user.recordUploadBytes(1, (err) => {
               if (err) {


### PR DESCRIPTION
Calling isUploadRateLimited will reset the time on the object without persisting the data to the database. Thus when recordUploadBytes is called it will think to increment the data instead of reseting it. Not modifying the in memory data when calling isUploadRateLimited fixes this issue.