### PR TITLE
add roles to user model

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -57,5 +57,10 @@ module.exports = {
   LOG_LEVEL_ERROR: 1,
   LOG_LEVEL_WARN: 2,
   LOG_LEVEL_INFO: 3,
-  LOG_LEVEL_DEBUG: 4
+  LOG_LEVEL_DEBUG: 4,
+  ROLES: [
+    'admin',
+    'moderator',
+    'user'
+  ]
 };

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -9,6 +9,7 @@ const SchemaOptions = require('../options');
 const { isValidEmail } = require('../utils');
 const uuid = require('uuid/v4');
 const validateUUID = require('uuid-validate');
+const ROLES = require('../constants.js').ROLES;
 
 /**
  * Represents a user
@@ -73,6 +74,11 @@ var UserSchema = new mongoose.Schema({
       default: false,
       required: true
     }
+  },
+  role: {
+    type: String,
+    enum: ROLES,
+    default: 'user'
   },
   bytesUploaded: {
     lastHourStarted: {


### PR DESCRIPTION
add roles to user model in preparation for admin dashboard 

- add user `role` attribute that has enum of constants
- initial roles of admin, moderator, and user.