### PR TITLE
Prevent contacts from saving with empty address fields

### DIFF
--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const mongoose = require('mongoose');
+const errors = require('storj-service-error-types');
 const SchemaOptions = require('../options');
 
 /**
@@ -82,6 +83,12 @@ ContactSchema.virtual('nodeID').get(function() {
 ContactSchema.statics.record = function(contactInfo, callback) {
   let Contact = this;
   let done = callback || function() {};
+
+  if (!contactInfo || !contactInfo.address) {
+    return callback(new errors.BadRequestError(
+      'Address is expected for contact'));
+  }
+
   let contact = new Contact({
     _id: contactInfo.nodeID,
     protocol: contactInfo.protocol,

--- a/test/contact.unit.js
+++ b/test/contact.unit.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon');
 const async = require('async');
 const expect = require('chai').expect;
+const errors = require('storj-service-error-types');
 const mongoose = require('mongoose');
 const storj = require('storj-lib');
 
@@ -66,6 +67,20 @@ describe('Storage/models/Contact', function() {
             done();
           });
         });
+      });
+    });
+
+    it('should not record with empty address', function(done) {
+      Contact.record({
+        port: 1337,
+        nodeID: storj.KeyPair().getNodeID(),
+        lastSeen: Date.now(),
+        spaceAvailable: true
+      }, function(err) {
+        expect(err);
+        expect(err).to.be.instanceOf(errors.BadRequestError);
+        expect(err.message).to.equal('Address is expected for contact');
+        done();
       });
     });
 


### PR DESCRIPTION
There is an issue with bridge-monitor in which contacts are unable to save because the address field is required. Let's check that the address field exists when `record` is used to update a contact.