### PR TITLE
[WIP] Set default values for reputation and responseTime

### DIFF
--- a/lib/models/contact.js
+++ b/lib/models/contact.js
@@ -6,6 +6,8 @@ const errors = require('storj-service-error-types');
 const SchemaOptions = require('../options');
 
 const constants = require('../constants');
+const DEFAULT_RESPONSE_TIME = 10000;
+const DEFAULT_REPUTATION = 0;
 
 /**
  * Represents a known contact
@@ -103,11 +105,25 @@ ContactSchema.statics.record = function(contactInfo, callback) {
     address: contactInfo.address,
     port: contactInfo.port,
     lastSeen: contactInfo.lastSeen,
+    responseTime: contactInfo.responseTime,
+    reputation: contactInfo.reputation,
     spaceAvailable: contactInfo.spaceAvailable
   });
 
   if (contactInfo && contactInfo.responseTime) {
     contact.responseTime = contactInfo.responseTime;
+  }
+
+  // Set default responseTime if it's not set, we should be careful
+  // here to set reset the responseTime. This method is used
+  // in Renter.prototype._onContactAdded in lib/renter of storj complex
+  // setting a default value in the model here will introduce a similar
+  // type of bug where the responseTime is constantly reset.
+  if (!contact.responseTime) {
+    contact.responseTime = DEFAULT_RESPONSE_TIME;
+  }
+  if (!contact.reputation) {
+    contact.reputation = DEFAULT_REPUTATION;
   }
 
   Contact.findOneAndUpdate({ _id: contactInfo.nodeID }, contact, {
@@ -183,7 +199,7 @@ ContactSchema.methods.recordResponseTime = function(responseTime) {
 
   // Contacts without response times start with untrusted 10 seconds
   // (timeout period) and can build improved times with each response.
-  const lastResponseTime = this.responseTime || 10000;
+  const lastResponseTime = this.responseTime || DEFAULT_RESPONSE_TIME;
 
   // Calculate the exponential moving average
   const k = 2 / (p + 1);

--- a/test/contact.unit.js
+++ b/test/contact.unit.js
@@ -63,7 +63,7 @@ describe('Storage/models/Contact', function() {
               return done(err);
             }
             expect(contact.spaceAvailable).to.equal(true);
-            expect(contact.responseTime).to.equal(undefined);
+            expect(contact.responseTime).to.equal(10000);
             done();
           });
         });
@@ -102,6 +102,92 @@ describe('Storage/models/Contact', function() {
             return done(err);
           }
           expect(contact.responseTime).to.equal(10000);
+          done();
+        });
+      });
+    });
+
+    it('should set a default responseTime if NOT supplied', function(done) {
+      const nodeID = storj.KeyPair().getNodeID();
+      Contact.record({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: nodeID,
+        lastSeen: Date.now()
+      }, (err) => {
+        if (err) {
+          return done(err);
+        }
+        Contact.findOne({_id: nodeID}, (err, contact) => {
+          if (err) {
+            return done(err);
+          }
+          expect(contact.responseTime).to.equal(10000);
+          done();
+        });
+      });
+    });
+
+    it('should NOT set a default responseTime if supplied', function(done) {
+      const nodeID = storj.KeyPair().getNodeID();
+      Contact.record({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: nodeID,
+        lastSeen: Date.now(),
+        responseTime: 600
+      }, (err) => {
+        if (err) {
+          return done(err);
+        }
+        Contact.findOne({_id: nodeID}, (err, contact) => {
+          if (err) {
+            return done(err);
+          }
+          expect(contact.responseTime).to.equal(600);
+          done();
+        });
+      });
+    });
+
+    it('should set a default reputation if NOT supplied', function(done) {
+      const nodeID = storj.KeyPair().getNodeID();
+      Contact.record({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: nodeID,
+        lastSeen: Date.now()
+      }, (err) => {
+        if (err) {
+          return done(err);
+        }
+        Contact.findOne({_id: nodeID}, (err, contact) => {
+          if (err) {
+            return done(err);
+          }
+          expect(contact.reputation).to.equal(0);
+          done();
+        });
+      });
+    });
+
+    it('should NOT set a default reputation if supplied', function(done) {
+      const nodeID = storj.KeyPair().getNodeID();
+      Contact.record({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: nodeID,
+        lastSeen: Date.now(),
+        reputation: 4000
+      }, (err) => {
+        if (err) {
+          return done(err);
+        }
+        Contact.findOne({_id: nodeID}, (err, contact) => {
+          if (err) {
+            return done(err);
+          }
+          expect(contact.reputation).to.equal(4000);
           done();
         });
       });


### PR DESCRIPTION
This is a quick fix until we deal with the high levels of software entropy that has accumulated. Fixes issue with new nodes not having a `responseTime` and thus not able to receive data on the network in farmer selection.

Strongly depends on https://github.com/Storj/core/pull/756 to avoid `reputation` and `responseTime` from being reset.

cc: @tempestb @littleskunk