### PR TITLE
Include the error code in returned error if bucket name exists

### DIFF
--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -4,6 +4,7 @@ const storj = require('storj-lib');
 const mongoose = require('mongoose');
 const SchemaOptions = require('../options');
 const crypto = require('crypto');
+const errors = require('storj-service-error-types');
 /**
  * Represents a storage bucket
  * @constructor
@@ -98,19 +99,23 @@ Bucket.statics.create = function(user, data, callback) {
   bucket.save(function(err) {
     if (err) {
       if (err.code === 11000) {
-        err.message = 'Name already used by another bucket';
+        return callback(
+          new errors.ConflictError('Name already used by another bucket')
+        );
       }
 
-      return callback(err);
+      return callback(new errors.InternalError(err.message));
     }
 
     Bucket.findOne({ _id: bucket._id }, function(err, bucket) {
       if (err) {
-        return callback(err);
+        return callback(new errors.InternalError(err.message));
       }
 
       if (!bucket) {
-        return callback(new Error('Failed to load created bucket'));
+        return callback(
+          new errors.InternalError('Failed to load created bucket')
+        );
       }
 
       callback(null, bucket);

--- a/lib/models/bucket.js
+++ b/lib/models/bucket.js
@@ -98,7 +98,7 @@ Bucket.statics.create = function(user, data, callback) {
   bucket.save(function(err) {
     if (err) {
       if (err.code === 11000) {
-        return callback(new Error('Name already used by another bucket'));
+        err.message = 'Name already used by another bucket';
       }
 
       return callback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-service-storage-models",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "description": "common storage models for various storj services",
   "main": "index.js",
   "directories": {

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -96,6 +96,7 @@ describe('Storage/models/Bucket', function() {
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
         function(err) {
+          expect(err.code).to.equal(11000);
           expect(err.message).to.equal('Name already used by another bucket');
           done();
       });

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -3,6 +3,7 @@
 const storj = require('storj-lib');
 const expect = require('chai').expect;
 const mongoose = require('mongoose');
+const errors = require('storj-service-error-types');
 
 require('mongoose-types').loadTypes(mongoose);
 
@@ -96,7 +97,7 @@ describe('Storage/models/Bucket', function() {
         { _id: 'user@domain.tld' },
         { name: 'New Bucket' },
         function(err) {
-          expect(err.code).to.equal(11000);
+          expect(err).to.be.instanceOf(errors.ConflictError);
           expect(err.message).to.equal('Name already used by another bucket');
           done();
       });


### PR DESCRIPTION
This way the bridge can compare the error code and return to clients
http error 409 instead of the generic http error 500.

Related to https://github.com/Storj/bridge/issues/322